### PR TITLE
feat: add unified lock operation method to reduce code duplication

### DIFF
--- a/yalexs/lock.py
+++ b/yalexs/lock.py
@@ -274,6 +274,12 @@ class LockDoorStatus(Enum):
     DISABLED = "disabled"
 
 
+class LockOperation(Enum):
+    LOCK = "lock"
+    UNLOCK = "unlock"
+    OPEN = "open"
+
+
 def determine_lock_status(status: str) -> LockStatus:
     if status in LOCKED_STATUS:
         return LockStatus.LOCKED


### PR DESCRIPTION
This PR introduces a unified `async_operate_lock` method to eliminate code duplication for consumers of the api
