### PR TITLE
fix(doorbell): recognise doorbell_call_button_press as a ding

### DIFF
--- a/known_activities.md
+++ b/known_activities.md
@@ -216,3 +216,35 @@
   }
 }
 ```
+
+## doorbell_call_button_press
+
+Button press on a Yale Smart Video Doorbell (`eagle_doorbell`, Yale "aa"
+platform). These doorbells do not push over PubNub/websocket; the press only
+appears in the house activity feed (`/houses/<houseId>/activities`).
+
+```
+{
+  "id": "<activityId>",
+  "timestamp": <epochTimestampMs>,
+  "icon": "https://activity-icon.aaecosystem.com/app/ActivityFeedIcons/doorbell_detected_doorbell_ring@3x.png",
+  "action": "doorbell_call_button_press",
+  "deviceID": "<doorbellId>",
+  "deviceType": "doorbell",
+  "attachment": "https://videocontent.aaecosystem.com/<houseId>/<doorbellId>/images/<activityId>.jpeg",
+  "attachmentWidth": 1920,
+  "attachmentHeight": 1080,
+  "doorbell": {
+    "contentToken": "<jwt>",
+    "dvrID": "<activityId>",
+    "videoUploadProgress": "not_started",
+    "videoAvailable": false,
+    "videoRecordingState": "recording_ongoing",
+    "eventContainsVideoContent": true
+  },
+  "reason": "DOORBELL_RING",
+  "otherReasonIcons": [],
+  "userActions": [],
+  "title": "<b><deviceName></b> pressed in <b><houseName></b>"
+}
+```

--- a/tests/fixtures/doorbell_call_button_press.json
+++ b/tests/fixtures/doorbell_call_button_press.json
@@ -1,0 +1,23 @@
+{
+  "id": "f507c53a-210d-48bb-b2f8-b575bc14e108",
+  "timestamp": 1788273328743,
+  "icon": "https://activity-icon.aaecosystem.com/app/ActivityFeedIcons/doorbell_detected_doorbell_ring@3x.png",
+  "action": "doorbell_call_button_press",
+  "deviceID": "K98GiDT45GUL",
+  "deviceType": "doorbell",
+  "attachment": "https://videocontent.aaecosystem.com/any/K98GiDT45GUL/images/f507c53a-210d-48bb-b2f8-b575bc14e108.jpeg",
+  "attachmentWidth": 1920,
+  "attachmentHeight": 1080,
+  "doorbell": {
+    "contentToken": "any",
+    "dvrID": "f507c53a-210d-48bb-b2f8-b575bc14e108",
+    "videoUploadProgress": "not_started",
+    "videoAvailable": false,
+    "videoRecordingState": "recording_ongoing",
+    "eventContainsVideoContent": true
+  },
+  "reason": "DOORBELL_RING",
+  "otherReasonIcons": [],
+  "userActions": [],
+  "title": "<b>Front Door</b> pressed in <b>Home</b>"
+}

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -12,6 +12,7 @@ from yalexs.activity import (
     ACTION_DOOR_OPEN,
     ACTION_DOOR_OPEN_2,
     ACTION_DOORBELL_BUTTON_PUSHED,
+    ACTION_DOORBELL_CALL_BUTTON_PRESS,
     ACTION_DOORBELL_CALL_HANGUP,
     ACTION_DOORBELL_CALL_INITIATED,
     ACTION_DOORBELL_CALL_MISSED,
@@ -73,7 +74,7 @@ from yalexs.activity import (
     LockOperationActivity,
 )
 from yalexs.api_async import ApiAsync
-from yalexs.api_common import API_GET_LOCK_URL, ApiCommon
+from yalexs.api_common import API_GET_LOCK_URL, ApiCommon, _activity_from_dict
 from yalexs.const import DEFAULT_BRAND
 from yalexs.lock import LockDoorStatus, LockStatus
 from yalexs.time import epoch_to_datetime
@@ -108,6 +109,7 @@ class TestActivity(unittest.TestCase):
                 ACTION_DOORBELL_BUTTON_PUSHED,
                 ACTION_DOORBELL_CALL_MISSED,
                 ACTION_DOORBELL_CALL_HANGUP,
+                ACTION_DOORBELL_CALL_BUTTON_PRESS,
                 ACTION_LOCK_DOORBELL_BUTTON_PUSHED,
             ],
         )
@@ -473,6 +475,26 @@ class TestActivity(unittest.TestCase):
         )
         assert doorbell_ding_activity.activity_start_time.timestamp() == 1691249378.0
         assert doorbell_ding_activity.activity_end_time.timestamp() == 1691249378.0
+
+    def test_get_doorbell_call_button_press(self):
+        """A button press on an eagle_doorbell (Yale "aa" platform) is a ding.
+
+        These doorbells never push over PubNub/websocket; the press only ever
+        shows up in the house activity feed as doorbell_call_button_press,
+        with the visitor still as a top-level attachment.
+        """
+        activity = _activity_from_dict(
+            SOURCE_LOG, json.loads(load_fixture("doorbell_call_button_press.json"))
+        )
+        assert isinstance(activity, DoorbellDingActivity)
+        assert activity.activity_type == ActivityType.DOORBELL_DING
+        assert activity.device_id == "K98GiDT45GUL"
+        assert activity.activity_start_time.timestamp() == 1788273328.743
+        assert activity.activity_end_time.timestamp() == 1788273328.743
+        assert activity.image_url == (
+            "https://videocontent.aaecosystem.com/any/K98GiDT45GUL/images/"
+            "f507c53a-210d-48bb-b2f8-b575bc14e108.jpeg"
+        )
 
 
 class TestActivityApiAsync(unittest.IsolatedAsyncioTestCase):

--- a/yalexs/activity.py
+++ b/yalexs/activity.py
@@ -54,6 +54,7 @@ ACTION_DOORBELL_CALL_INITIATED = "doorbell_call_initiated"
 ACTION_DOORBELL_MOTION_DETECTED = "doorbell_motion_detected"
 ACTION_DOORBELL_CALL_MISSED = "doorbell_call_missed"
 ACTION_DOORBELL_CALL_HANGUP = "doorbell_call_hangup"
+ACTION_DOORBELL_CALL_BUTTON_PRESS = "doorbell_call_button_press"
 ACTION_LOCK_DOORBELL_BUTTON_PUSHED = "lock_accessory_motion_detect"
 
 ACTION_BRIDGE_ONLINE = "associated_bridge_online"  # pubnub only
@@ -67,6 +68,7 @@ ACTIVITY_ACTIONS_DOORBELL_DING = {
     ACTION_DOORBELL_BUTTON_PUSHED,
     ACTION_DOORBELL_CALL_MISSED,
     ACTION_DOORBELL_CALL_HANGUP,
+    ACTION_DOORBELL_CALL_BUTTON_PRESS,
     ACTION_LOCK_DOORBELL_BUTTON_PUSHED,
 }
 ACTIVITY_ACTIONS_DOORBELL_IMAGE_CAPTURE = {ACTION_DOORBELL_IMAGE_CAPTURE}
@@ -424,7 +426,11 @@ class DoorbellBaseActionActivity(Activity):
     @cached_property
     def image_url(self):
         """Return the image URL of the activity."""
-        return self._info.get("image") or self._info.get("attachment")
+        return (
+            self._info.get("image")
+            or self._info.get("attachment")
+            or self._data.get("attachment")
+        )
 
     @cached_property
     def activity_start_time(self):


### PR DESCRIPTION
## What

Recognise `doorbell_call_button_press` as a doorbell ding.

## Why

The Yale Smart Video Doorbell (`type: eagle_doorbell`, Yale "aa" platform, `api.aaecosystem.com`) never pushes doorbell events over PubNub or the websocket — with `yalexs` at debug, two test presses produced zero websocket messages for the doorbell while the lock's messages flowed on the same connection. So the `buttonpush` action this library expects for a ring can never occur on this hardware.

A press only ever appears in the house activity feed (`/houses/<houseId>/activities`), as `action: doorbell_call_button_press`, which `_activity_from_dict` logged as `Unknown activity` and dropped. `DoorbellDingActivity` was therefore never produced, and Home Assistant's ding `binary_sensor` and doorbell `event` entity never fired for these devices (motion works, because `doorbell_motion_detected` is recognised and the 10 s poll picks it up within a few seconds).

Fixes #442 (the ding half; observed on firmware 1.7.3-D6+20260213075301, HA 2026.8.3 / yalexs 9.2.10, code unchanged on 9.2.13 and `main`).

## Changes

- `yalexs/activity.py`: add `ACTION_DOORBELL_CALL_BUTTON_PRESS` to `ACTIVITY_ACTIONS_DOORBELL_DING`. The payload carries the visitor still as a top-level `attachment` (as the motion activities on this platform do), so `DoorbellBaseActionActivity.image_url` now falls back to that, mirroring `BaseDoorbellMotionActivity`.
- `tests/fixtures/doorbell_call_button_press.json`: a real feed entry with identifiers anonymised.
- `tests/test_activity.py`: ding-set assertion updated; new test that the dict maps to `DoorbellDingActivity` with the expected type, device, start/end time and image URL.
- `known_activities.md`: document the payload shape.

## Verification

`pytest`: 463 passed, coverage unchanged at 99%. `ruff check` / `ruff format --check` clean.

Raw payload as received (IDs and token elided):

```
{'id': '…', 'timestamp': 1788273328743,
 'icon': 'https://activity-icon.aaecosystem.com/app/ActivityFeedIcons/doorbell_detected_doorbell_ring@3x.png',
 'action': 'doorbell_call_button_press', 'deviceID': '…', 'deviceType': 'doorbell',
 'attachment': 'https://videocontent.aaecosystem.com/<house>/<doorbell>/images/<id>.jpeg',
 'attachmentWidth': 1920, 'attachmentHeight': 1080,
 'doorbell': {'contentToken': '…', 'dvrID': '…', 'videoUploadProgress': 'not_started',
              'videoAvailable': False, 'videoRecordingState': 'recording_ongoing',
              'eventContainsVideoContent': True},
 'reason': 'DOORBELL_RING', 'otherReasonIcons': [], 'userActions': [...],
 'title': '<b>Front Door Doorbell Camera</b> pressed in <b>…</b>'}
```
